### PR TITLE
Ignores node_modules to prevent conflicts in dependencies

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const { basename } = require("path");
+const { basename, relative } = require("path");
 const not = require("logical-not");
 
 
@@ -13,6 +13,7 @@ export default function({ types: t }) {
     return {
         visitor: {
             Identifier(path, { opts: options, file }) {
+                if (relative(file.opts.root, file.opts.filename).match(/^node_modules/)) return;
                 if (not(isCorrectIdentifier(path))) return;
 
                 let { node: identifier, scope } = path;

--- a/test/test.js
+++ b/test/test.js
@@ -571,4 +571,19 @@ describe("Tests", () => {
 
         assert.isTrue(isEqual(input, output, [declaration], filename));
     });
+
+    it("case 28 - ignore node_modules", () => {
+        let input = `
+            someVariable;
+        `;
+        let filename = 'node_modules/default.js';
+        let declaration = {
+            default: "someVariable", path: "some-path/some-module.js"
+        };
+        let output = `
+            someVariable;
+        `;
+
+        assert.isTrue(isEqual(input, output, [declaration], filename));
+    });
 });


### PR DESCRIPTION
This fixes Issue #3.

I figured that since you'd only want to auto import within your own project and it'd be strange for some dependency in `node_modules` to expect an auto-import, it would be safe to just ignore `node_modules` entirely.

This would be a good quick fix for most cases where such a problem would occur.

I have tested this in my project and it seems to work. However, this is the first time I've worked on a babel plugin, so please double-check to make sure that there isn't something I overlooked. 