### PR TITLE
now import * as namespace is supported!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lib
 *.log
+.idea

--- a/README.md
+++ b/README.md
@@ -102,6 +102,38 @@ fetch("http://example.com/qwe");
 
 ### Example 4
 
+import * as namespace from a esModule
+
+**.babelrc**
+
+```json
+{
+  "plugins": [[
+    "auto-import", {
+      "declarations": [
+        { "namespace": "toolkitNamespace", "path": "@toolkit/core" }
+      ]
+    }
+  ]]
+}
+```
+
+**In**
+
+```javascript
+toolkit.debounce();
+```
+
+**Out**
+
+```javascript
+import * as toolkitNamespace from "@toolkit/core";
+
+toolkit.debounce();
+```
+
+### Example 5
+
 Generate import path by filename. [name] will be replaced to processed filename.
 
 **.babelrc**

--- a/package.json
+++ b/package.json
@@ -1,39 +1,38 @@
 {
-  "name": "babel-plugin-auto-import",
-  "version": "1.1.0",
-  "description": "Babel plugin for variable auto imports",
-  "main": "lib/index.js",
-  "scripts": {
-    "build": "rimraf lib && babel src --out-dir lib",
-    "dev": "rimraf lib && babel src --out-dir lib --source-maps --watch",
-    "prepublish": "npm run build",
-    "test": "npm run build && mocha"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/PavelDymkov/babel-plugin-auto-import.git"
-  },
-  "keywords": [
-    "babel-plugin",
-    "import",
-    "module"
-  ],
-  "author": "Pavel Dymkov <dymkov86@gmail.com>",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/PavelDymkov/babel-plugin-auto-import/issues"
-  },
-  "homepage": "https://github.com/PavelDymkov/babel-plugin-auto-import#readme",
-  "devDependencies": {
-    "@babel/cli": "^7.10.5",
-    "@babel/preset-env": "^7.11.0",
-    "babel-plugin-transform-enum-literal": "^1.0.5",
-    "chai": "^4.2.0",
-    "mocha": "^8.1.1",
-    "rimraf": "^3.0.2"
-  },
-  "dependencies": {
-    "@babel/core": "^7.11.1",
-    "logical-not": "^1.0.1"
-  }
+    "name" : "babel-plugin-auto-import" ,
+    "version" : "1.1.0" ,
+    "description" : "Babel plugin for variable auto imports" ,
+    "main" : "lib/index.js" ,
+    "scripts" : {
+        "build" : "rimraf lib && babel src --out-dir lib" ,
+        "dev" : "rimraf lib && babel src --out-dir lib --source-maps --watch" ,
+        "prepublish" : "npm run build" ,
+        "test" : "npm run build && mocha"
+    } ,
+    "repository" : {
+        "type" : "git" ,
+        "url" : "git+https://github.com/PavelDymkov/babel-plugin-auto-import.git"
+    } ,
+    "keywords" : [
+        "babel-plugin" ,
+        "import" ,
+        "module"
+    ] ,
+    "author" : "Pavel Dymkov <dymkov86@gmail.com>" ,
+    "license" : "ISC" ,
+    "bugs" : {
+        "url" : "https://github.com/PavelDymkov/babel-plugin-auto-import/issues"
+    } ,
+    "homepage" : "https://github.com/PavelDymkov/babel-plugin-auto-import#readme" ,
+    "devDependencies" : {
+        "@babel/cli" : "^7.10.5" ,
+        "@babel/preset-env" : "^7.11.0" ,
+        "chai" : "^4.2.0" ,
+        "mocha" : "^8.1.1" ,
+        "rimraf" : "^3.0.2"
+    } ,
+    "dependencies" : {
+        "@babel/core" : "^7.11.1" ,
+        "logical-not" : "^1.0.1"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,38 +1,38 @@
 {
-    "name" : "babel-plugin-auto-import" ,
-    "version" : "1.1.0" ,
-    "description" : "Babel plugin for variable auto imports" ,
-    "main" : "lib/index.js" ,
-    "scripts" : {
-        "build" : "rimraf lib && babel src --out-dir lib" ,
-        "dev" : "rimraf lib && babel src --out-dir lib --source-maps --watch" ,
-        "prepublish" : "npm run build" ,
-        "test" : "npm run build && mocha"
-    } ,
-    "repository" : {
-        "type" : "git" ,
-        "url" : "git+https://github.com/PavelDymkov/babel-plugin-auto-import.git"
-    } ,
-    "keywords" : [
-        "babel-plugin" ,
-        "import" ,
-        "module"
-    ] ,
-    "author" : "Pavel Dymkov <dymkov86@gmail.com>" ,
-    "license" : "ISC" ,
-    "bugs" : {
-        "url" : "https://github.com/PavelDymkov/babel-plugin-auto-import/issues"
-    } ,
-    "homepage" : "https://github.com/PavelDymkov/babel-plugin-auto-import#readme" ,
-    "devDependencies" : {
-        "@babel/cli" : "^7.10.5" ,
-        "@babel/preset-env" : "^7.11.0" ,
-        "chai" : "^4.2.0" ,
-        "mocha" : "^8.1.1" ,
-        "rimraf" : "^3.0.2"
-    } ,
-    "dependencies" : {
-        "@babel/core" : "^7.11.1" ,
-        "logical-not" : "^1.0.1"
-    }
+  "name": "babel-plugin-auto-import",
+  "version": "1.1.0",
+  "description": "Babel plugin for variable auto imports",
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "rimraf lib && babel src --out-dir lib",
+    "dev": "rimraf lib && babel src --out-dir lib --source-maps --watch",
+    "prepublish": "npm run build",
+    "test": "npm run build && mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/PavelDymkov/babel-plugin-auto-import.git"
+  },
+  "keywords": [
+    "babel-plugin",
+    "import",
+    "module"
+  ],
+  "author": "Pavel Dymkov <dymkov86@gmail.com>",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/PavelDymkov/babel-plugin-auto-import/issues"
+  },
+  "homepage": "https://github.com/PavelDymkov/babel-plugin-auto-import#readme",
+  "devDependencies": {
+    "@babel/cli": "^7.10.5",
+    "@babel/preset-env": "^7.11.0",
+    "chai": "^4.2.0",
+    "mocha": "^8.1.1",
+    "rimraf": "^3.0.2"
+  },
+  "dependencies": {
+    "@babel/core": "^7.11.1",
+    "logical-not": "^1.0.1"
+  }
 }

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -1,4 +1,3 @@
 {
-  "presets": ["@babel/preset-env"],
-  "plugins": ["babel-plugin-transform-enum-literal"]
+  "presets": ["@babel/preset-env"]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,220 +1,238 @@
 const { basename } = require("path");
 const not = require("logical-not");
 
-const ImportType = ({
-    DEFAULT,
-    MEMBER,
-    ANONYMOUS,
+const ImportTypeEnum = ({
+    /*support:import * as namespace*/
+    NAMESPACE : Symbol("NAMESPACE") ,
+    DEFAULT : Symbol("DEFAULT") ,
+    MEMBER : Symbol("MEMBER") ,
+    ANONYMOUS : Symbol("ANONYMOUS"),
 });
 
-export default function ({ types: t }) {
+module.exports = function ({ types : t }) {
     return {
-        visitor: {
+        visitor : {
             Identifier(path, { opts: options, file }) {
-                if (not(path.isReferencedIdentifier())) return;
-
+                if ( not(path.isReferencedIdentifier()) ) return;
+                
                 let { node: identifier, scope } = path;
-
-                if (isDefined(identifier, scope)) return;
-
+                
+                if ( isDefined(identifier , scope) ) return;
+                
                 let { declarations } = options;
-
-                if (not(Array.isArray(declarations))) return;
-
-                let filename = file.opts.filename
-                    ? basename(file.opts.filename)
-                    : "";
-
-                declarations.some(handleDeclaration, {
-                    path,
-                    identifier,
-                    filename,
+                
+                if ( not(Array.isArray(declarations)) ) return;
+                
+                let filename = file.opts.filename ? basename(file.opts.filename) : "";
+                
+                declarations.forEach(handleDeclaration , {
+                    path ,
+                    identifier ,
+                    filename ,
                 });
-            },
-        },
+            } ,
+        } ,
     };
-
+    
     function isDefined(identifier, { bindings, parent }) {
         let variables = Object.keys(bindings);
-
-        if (variables.some(has, identifier)) return true;
-
-        return parent ? isDefined(identifier, parent) : false;
+        
+        if ( variables.some(has , identifier) ) return true;
+        
+        return parent ? isDefined(identifier , parent) : false;
     }
-
-    function has(identifier) {
+    
+    function has (identifier) {
         let { name } = this;
-
+        
         return identifier == name;
     }
-
-    function handleDeclaration(declaration) {
+    
+    function handleDeclaration (declaration) {
         let { path, identifier, filename } = this;
-
-        if (not(declaration)) return;
-
-        let importType = null;
-
-        if (hasDefault(declaration, identifier)) {
-            importType = ImportType.DEFAULT;
-        } else if (hasMember(declaration, identifier)) {
-            importType = ImportType.MEMBER;
-        } else if (hasAnonymous(declaration, identifier)) {
-            importType = ImportType.ANONYMOUS;
+        
+        if ( not(declaration) ) return;
+        
+        const program = path.findParent((path) => path.isProgram());
+        const pathToModule = getPathToModule(declaration , filename);
+        
+        let types = [];
+        if ( hasDefault(declaration , identifier) ) {
+            types.push(ImportTypeEnum.DEFAULT);
+        } 
+        
+        if ( hasMember(declaration , identifier) ) {
+            types.push(ImportTypeEnum.MEMBER);
+        } 
+        
+        if ( hasAnonymous(declaration , identifier) ) {
+            types.push(ImportTypeEnum.ANONYMOUS);
         }
-
-        if (importType) {
-            let program = path.findParent(isProgram);
-            let pathToModule = getPathToModule(declaration, filename);
-
-            insertImport(program, identifier, importType, pathToModule);
-
-            return true;
+        
+        /**
+         * support:
+         * import * as somethingModule from 'something';
+         * import something from 'something';
+         */
+        if ( hasNamespace(declaration , identifier) ) {
+            types.push(ImportTypeEnum.NAMESPACE);
         }
+        insertImport(program , identifier , types , pathToModule);
     }
-
-    function hasDefault(declaration, identifier) {
+    
+    function hasDefault (declaration , identifier) {
         return declaration["default"] == identifier.name;
     }
-
-    function hasMember(declaration, identifier) {
-        let members = Array.isArray(declaration.members)
-            ? declaration.members
-            : [];
-
-        return members.some(has, identifier);
+    
+    function hasNamespace (declaration , identifier) {
+        return declaration["namespace"] == identifier.name;
     }
-
-    function hasAnonymous(declaration, identifier) {
-        let anonymous = Array.isArray(declaration.anonymous)
-            ? declaration.anonymous
-            : [];
-
-        return anonymous.some(has, identifier);
+    
+    function hasMember (declaration , identifier) {
+        let members = Array.isArray(declaration.members) ? declaration.members : [];
+        
+        return members.some(has , identifier);
     }
-
-    function insertImport(program, identifier, type, pathToModule) {
+    
+    function hasAnonymous (declaration , identifier) {
+        let anonymous = Array.isArray(declaration.anonymous) ? declaration.anonymous : [];
+        
+        return anonymous.some(has , identifier);
+    }
+    
+    function generateSpecifiers (identifier , types) {
+        
+        return types.reduce((accum,type) => {
+            switch ( type ) {
+                case ImportTypeEnum.DEFAULT : {
+                    accum.push(t.importDefaultSpecifier(identifier));
+                    break;
+                }
+                case ImportTypeEnum.NAMESPACE : {
+                    /*skip it , will add an another import statement for namespace*/
+                    break;
+                }
+                case ImportTypeEnum.ANONYMOUS : {
+                    break;
+                }
+                case ImportTypeEnum.MEMBER : {
+                    accum.push(t.importSpecifier(identifier , identifier));
+                    break;
+                }
+            }
+            return accum;
+        },[]);
+    }
+    
+    function insertImport (program , identifier , types , pathToModule) {
         let programBody = program.get("body");
-
-        let currentImportDeclarations = programBody.reduce(
-            toImportDeclarations,
-            []
-        );
-
-        let importDidAppend;
-
-        importDidAppend = currentImportDeclarations.some(importAlreadyExists, {
-            identifier,
-            type,
-            pathToModule,
+        
+        let currentImportDeclarations = programBody.reduce(toImportDeclarations , []);
+        
+        
+        types.forEach((type) => {
+            let importDidAppend;
+            importDidAppend = currentImportDeclarations.some(importAlreadyExists , {
+                identifier ,
+                type ,
+                pathToModule ,
+            });
+            if ( importDidAppend ) return;
+            importDidAppend = currentImportDeclarations.some(addToImportDeclaration , {
+                identifier ,
+                type ,
+                pathToModule ,
+            });
+            if ( importDidAppend ) return;
+            
+            
+            if(types.includes(ImportTypeEnum.NAMESPACE)){
+                program.unshiftContainer("body" , t.importDeclaration([t.importNamespaceSpecifier(identifier)],t.stringLiteral(pathToModule)));
+            }
+            
+            const specifiers = generateSpecifiers(identifier , types);
+            
+            let importDeclaration = t.importDeclaration(specifiers , t.stringLiteral(pathToModule));
+            
+            program.unshiftContainer("body" , importDeclaration);
+            
         });
-
-        if (importDidAppend) return;
-
-        importDidAppend = currentImportDeclarations.some(
-            addToImportDeclaration,
-            { identifier, type, pathToModule }
-        );
-
-        if (importDidAppend) return;
-
-        let specifiers = [];
-
-        if (type == ImportType.DEFAULT) {
-            specifiers.push(t.importDefaultSpecifier(identifier));
-        } else if (type == ImportType.MEMBER) {
-            specifiers.push(t.importSpecifier(identifier, identifier));
-        } else if (type == ImportType.ANONYMOUS) {
-        }
-
-        let importDeclaration = t.importDeclaration(
-            specifiers,
-            t.stringLiteral(pathToModule)
-        );
-
-        program.unshiftContainer("body", importDeclaration);
     }
-
-    function isProgram(path) {
-        return path.isProgram();
-    }
-
-    function toImportDeclarations(list, currentPath) {
-        if (currentPath.isImportDeclaration()) list.push(currentPath);
-
+    
+    
+    function toImportDeclarations (list , currentPath) {
+        if ( currentPath.isImportDeclaration() ) list.push(currentPath);
+        
         return list;
     }
-
-    function importAlreadyExists({ node: importDeclaration }) {
+    
+    function importAlreadyExists ({ node : importDeclaration }) {
         let { identifier, type, pathToModule } = this;
-
-        if (importDeclaration.source.value == pathToModule) {
-            if (type == ImportType.ANONYMOUS) return true;
-
-            return importDeclaration.specifiers.some(
-                checkSpecifierLocalName,
-                identifier
-            );
+        
+        if ( importDeclaration.source.value == pathToModule ) {
+            if ( type == ImportTypeEnum.ANONYMOUS ) return true;
+            
+            return importDeclaration.specifiers.some(checkSpecifierLocalName , identifier);
         }
     }
-
-    function checkSpecifierLocalName(specifier) {
+    
+    function checkSpecifierLocalName (specifier) {
         let identifier = this;
-
+        
         return specifier.local.name == identifier.name;
     }
-
-    function addToImportDeclaration(importDeclarationPath) {
+    
+    function addToImportDeclaration (importDeclarationPath) {
         let { identifier, type, pathToModule } = this;
         let { node } = importDeclarationPath;
-
-        if (node.source.value != pathToModule) return false;
-
+        
+        if ( node.source.value != pathToModule ) return false;
+        
         let { specifiers } = node;
-
-        if (type == ImportType.DEFAULT) {
-            if (not(specifiers.some(hasImportDefaultSpecifier))) {
+        
+        if ( type == ImportTypeEnum.DEFAULT ) {
+            if ( not(specifiers.some(hasImportDefaultSpecifier)) ) {
                 let specifier = t.importDefaultSpecifier(identifier);
-
-                importDeclarationPath.unshiftContainer("specifiers", specifier);
-
+                
+                importDeclarationPath.unshiftContainer("specifiers" , specifier);
+                
                 return true;
             }
         }
-
-        if (type == ImportType.MEMBER) {
-            if (not(specifiers.some(hasSpecifierWithName, identifier))) {
-                let specifier = t.importSpecifier(identifier, identifier);
-
-                importDeclarationPath.pushContainer("specifiers", specifier);
-
+        
+        if ( type == ImportTypeEnum.MEMBER ) {
+            if ( not(specifiers.some(hasSpecifierWithName , identifier)) ) {
+                let specifier = t.importSpecifier(identifier , identifier);
+                
+                importDeclarationPath.pushContainer("specifiers" , specifier);
+                
                 return true;
             }
         }
     }
-
-    function hasImportDefaultSpecifier(node) {
+    
+    function hasImportDefaultSpecifier (node) {
         return t.isImportDefaultSpecifier(node);
     }
-
-    function hasSpecifierWithName(node) {
-        if (not(t.isImportSpecifier(node))) return false;
-
+    
+    function hasSpecifierWithName (node) {
+        if ( not(t.isImportSpecifier(node)) ) return false;
+        
         let { name } = this;
-
+        
         return node.imported.name == name;
     }
-
-    function getPathToModule(declaration, filename) {
-        if (declaration.path.includes("[name]")) {
+    
+    function getPathToModule (declaration , filename) {
+        if ( declaration.path.includes("[name]") ) {
             let pattern = declaration.nameReplacePattern || "\\.js$";
             let newSubString = declaration.nameReplaceString || "";
-
-            let name = filename.replace(new RegExp(pattern), newSubString);
-
-            return declaration.path.replace("[name]", name);
+            
+            let name = filename.replace(new RegExp(pattern) , newSubString);
+            
+            return declaration.path.replace("[name]" , name);
         }
-
+        
         return declaration.path;
     }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -2,9 +2,9 @@ const babel = require("@babel/core");
 const { assert } = require("chai");
 
 const babelOptions = {
-    plugins: [[require("../").default, { declarations: null }]],
+    plugins: [[require("../"), { declarations: null }]],
 };
-const spaces = /\s+/g;
+const spaces = /(\s|\t|\r|\n)+/g;
 
 function isEqual(input, expected, declarations, filename) {
     babelOptions.plugins[0][1].declarations = declarations;
@@ -19,12 +19,12 @@ function isEqual(input, expected, declarations, filename) {
     let output = babel.transform(input, babelOptions).code;
 
     if (needDeleteFilename) delete babelOptions.filename;
-
-    return output.replace(spaces, "") == expected.replace(spaces, "");
+    /*the outputed code will be printed when went wrong*/
+    return (output.replace(spaces, "") == expected.replace(spaces, "")) || (console.log(output),false);
 }
 
 describe("Tests", () => {
-    it("case 1", () => {
+    it(`case f3004854`, () => {
         let input = `
             someVariable;
         `;
@@ -41,7 +41,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 2", () => {
+    it(`case 72abd8ee`, () => {
         let input = `
             import someVariable from "some-path/some-module.js";
 
@@ -60,7 +60,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 3", () => {
+    it(`case eb873e18`, () => {
         let input = `
             someVariable;
         `;
@@ -77,7 +77,33 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 4", () => {
+    it(`case 8ac619cd`, () => {
+        let input = `
+            toolkitNamespace.debounce;
+            toolkit.debounce;
+            debounce;
+            toolkit();
+        `;
+        let declaration = {
+            members: ["debounce"],
+            namespace : "toolkitNamespace",
+	         default : "toolkit",
+            path: "@toolkit/core",
+        };
+        let output = `
+            import toolkit, { debounce } from "@toolkit/core";
+            import * as toolkitNamespace from "@toolkit/core";
+            
+            toolkitNamespace.debounce;
+            toolkit.debounce;
+            debounce;
+            toolkit();
+        `;
+
+        assert.isTrue(isEqual(input, output, [declaration]));
+    });
+
+    it(`case 50c90cc6`, () => {
         let input = `
             import z from "some-path/y.js";
 
@@ -122,7 +148,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, declarations));
     });
 
-    it("case 5", () => {
+    it(`case 899bff85`, () => {
         let input = `
             let someVariable;
         `;
@@ -137,7 +163,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 6", () => {
+    it(`case 5fbad1c9`, () => {
         let input = `
             import { q } from "some-path";
 
@@ -181,7 +207,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 7", () => {
+    it(`case 647cf2b1`, () => {
         let input = `
             x.y.z;
         `;
@@ -198,7 +224,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 8", () => {
+    it(`case b26b1bcc`, () => {
         let input = `
             let a = x.b();
             let c = d.b();
@@ -217,7 +243,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 9", () => {
+    it(`case 31666940`, () => {
         let input = `
             x:
             for (let i = 0; i < 10; i++) {
@@ -238,7 +264,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 10", () => {
+    it(`case b6cee56d`, () => {
         let input = `
             try {
                 class x {
@@ -257,7 +283,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 11", () => {
+    it(`case 122196f2`, () => {
         let input = `
             function x() { }
 
@@ -275,7 +301,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 12", () => {
+    it(`case 8396261c`, () => {
         let input = `
             ({ x } = a);
 
@@ -290,7 +316,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 13", () => {
+    it(`case 6e20dac7`, () => {
         let input = `
             export default x;
         `;
@@ -307,7 +333,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 14", () => {
+    it(`case 2079f24e`, () => {
         let input = `
             let a = {
                 b: x,
@@ -332,7 +358,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 15", () => {
+    it(`case 0bc2d1bd`, () => {
         let input = `
             (function () {
                 let a = x;
@@ -355,7 +381,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 16", () => {
+    it(`case bfd8b1ed`, () => {
         let input = `
             let a = b + x;
         `;
@@ -372,7 +398,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 17", () => {
+    it(`case e584d067`, () => {
         let input = `
             let a = x ? y : z;
         `;
@@ -389,7 +415,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 18", () => {
+    it(`case 379f0b96`, () => {
         let input = `
             let a = b => x;
 
@@ -414,7 +440,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 19", () => {
+    it(`case 6cf0cf3d`, () => {
         let input = `
             for (let a in x) {}
 
@@ -435,7 +461,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 20", () => {
+    it(`case 9aa5a8d0`, () => {
         let input = `
             new x;
             new a.y();
@@ -456,7 +482,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 21", () => {
+    it(`case 4f1e9272`, () => {
         let input = `
             function a() {
                 return x;
@@ -485,7 +511,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 22", () => {
+    it(`case 97d9847b`, () => {
         let input = `
             throw x;
             +y;
@@ -504,7 +530,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 23", () => {
+    it(`case b24f8825`, () => {
         let input = `
             class A extends X { }
 
@@ -525,7 +551,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 24", () => {
+    it(`case f6838ccb`, () => {
         let input = `
             someVariable;
         `;
@@ -542,7 +568,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 25", () => {
+    it(`case 796ad655`, () => {
         let input = `
             let x = a + b;
         `;
@@ -559,7 +585,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration]));
     });
 
-    it("case 26", () => {
+    it(`case ce351f9a`, () => {
         let input = `
             styles.className;
         `;
@@ -577,7 +603,7 @@ describe("Tests", () => {
         assert.isTrue(isEqual(input, output, [declaration], filename));
     });
 
-    it("case 27", () => {
+    it(`case 9a2dfe69`, () => {
         let input = `
             styles.className;
         `;


### PR DESCRIPTION
* prefered code logic, and now supported import * as namespace from "module"
* removed babel-enum-literal-plugin because it could make things trouble and complex , so I replaced them with simple symbols;
* added test for import as namespace , and replaced case number by uuid;
* all tests have been passed;
![image](https://user-images.githubusercontent.com/40685018/222286633-f83ba4ec-fcb5-498a-a3a6-f9db774f1b3c.png)
